### PR TITLE
Add TypeScript declaration file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@semantic-release/github": "^8.0.7",
         "@semantic-release/npm": "^10.0.3",
         "@semantic-release/release-notes-generator": "^11.0.1",
+        "@types/marked": "^4.3.0",
         "babel-jest": "^29.5.0",
         "eslint": "^8.40.0",
         "eslint-config-standard": "^17.0.0",
@@ -3272,6 +3273,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "node_modules/@types/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-zK4gSFMjgslsv5Lyvr3O1yCjgmnE4pr8jbG8qVn4QglMwtpvPCf4YT2Wma7Nk95OxUUJI8Z+kzdXohbM7mVpGw==",
       "dev": true
     },
     "node_modules/@types/minimist": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./lib/index.cjs",
   "module": "./src/index.js",
   "browser": "./lib/index.umd.js",
+  "types": "./src/index.d.ts",
   "type": "module",
   "keywords": [
     "marked",
@@ -49,6 +50,7 @@
     "@semantic-release/github": "^8.0.7",
     "@semantic-release/npm": "^10.0.3",
     "@semantic-release/release-notes-generator": "^11.0.1",
+    "@types/marked": "^4.3.0",
     "babel-jest": "^29.5.0",
     "eslint": "^8.40.0",
     "eslint-config-standard": "^17.0.0",

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -161,7 +161,7 @@ no need to escape chars
         });
       }
     }));
-    expect(await marked(markdown, { async: true })).toMatchInlineSnapshot(`
+    expect(await marked(markdown)).toMatchInlineSnapshot(`
 "<pre><code class="language-javascript"><div class="highlight"><pre><span class="kr">const</span> <span class="nx">highlight</span> <span class="o">=</span> <span class="s2">&quot;code&quot;</span><span class="p">;</span>
 </pre></div>
 </code></pre>"

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -161,7 +161,7 @@ no need to escape chars
         });
       }
     }));
-    expect(await marked(markdown)).toMatchInlineSnapshot(`
+    expect(await marked(markdown, { async: true })).toMatchInlineSnapshot(`
 "<pre><code class="language-javascript"><div class="highlight"><pre><span class="kr">const</span> <span class="nx">highlight</span> <span class="o">=</span> <span class="s2">&quot;code&quot;</span><span class="p">;</span>
 </pre></div>
 </code></pre>"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,80 @@
+declare module 'marked-highlight' {
+  /**
+   * A synchronous function to highlight code
+   *
+   * @param code The raw code to be highlighted
+   * @param language The language tag found immediately after the code block opening marker (e.g. ```typescript -> language='typescript')
+   * @return The highlighted code as a HTML string
+   */
+  type SyncHighlightFunction = (code: string, language: string) => string;
+
+  /**
+   * An asynchronous function to highlight code
+   *
+   * @param code The raw code to be highlighted
+   * @param language The language tag found immediately after the code block opening marker (e.g. ```typescript -> language='typescript')
+   * @return A Promise for the highlighted code as a HTML string
+   */
+  type AsyncHighlightFunction = (code: string, language: string) => Promise<string>;
+
+  /**
+   * Options for configuring the marked-highlight extension using a synchronous highlighting function.
+   */
+  interface SynchronousOptions {
+    /** Function to highlight code with */
+    highlight: SyncHighlightFunction;
+    /** Not necessary when using a synchronous highlighting function, but can be set without harm (will make `marked.parse()` return a promise if true) */
+    async?: boolean;
+    /** The language tag found immediately after the code block opening marker is appended to this to form the class attribute added to the <code> element. */
+    langPrefix?: string;
+  }
+
+  /**
+   * Options for configuring the marked-highlight extension using an asynchronous highlighting function.
+   * 
+   * Note that the {async: true} option must also be passed to markdown.parse() when using an asynchronous highlighting function.
+   */
+  interface AsynchronousOptions {
+    /** Function to highlight code with */
+    highlight: AsyncHighlightFunction;
+    /** Must be set to true when using an asynchronous highlight function */
+    async: true;
+    /** The language tag found immediately after the code block opening marker is appended to this to form the class attribute added to the <code> element. */
+    langPrefix?: string;
+  }
+
+  /**
+   * Configures a marked extension to apply syntax highlighing to code elements.
+   *
+   * @param options Options for the extension
+   * @return A MarkedExtension to be passed to `marked.use()`
+   */
+  export function markedHighlight(options: SynchronousOptions): import('marked').MarkedExtension;
+
+  /**
+   * Configures a marked extension to apply syntax highlighing to code elements.
+   *
+   * @param options Options for the extension
+   * @return A MarkedExtension to be passed to `marked.use()`
+   */
+  export function markedHighlight(options: AsynchronousOptions): import('marked').MarkedExtension;
+
+  /**
+   * Configures a marked extension to apply syntax highlighing to code elements.
+   *
+   * @param highlightFunction A synchronous function to apply syntax highlighting
+   * @return A MarkedExtension to be passed to `marked.use()`
+   */
+  export function markedHighlight(
+    highlightFunction: SyncHighlightFunction
+  ): import('marked').MarkedExtension;
+
+  /**
+   * Encode special characters (ampersands, angle brackets, and quotes) in code as their respective HTML entities
+   * 
+   * @param code The code to be encoded
+   * @param encode If true, blindly encodes all ampersands. If false, uses a more complicate regex to avoid re-encoding the ampersand at the start of existing HTML entities in the code
+   * @return The code with the special characters encoded.
+   */
+  export function encode(code: string, encode: boolean): string;
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -68,13 +68,4 @@ declare module 'marked-highlight' {
   export function markedHighlight(
     highlightFunction: SyncHighlightFunction
   ): import('marked').MarkedExtension;
-
-  /**
-   * Encode special characters (ampersands, angle brackets, and quotes) in code as their respective HTML entities
-   * 
-   * @param code The code to be encoded
-   * @param encode If true, blindly encodes all ampersands. If false, uses a more complicate regex to avoid re-encoding the ampersand at the start of existing HTML entities in the code
-   * @return The code with the special characters encoded.
-   */
-  export function encode(code: string, encode: boolean): string;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,8 @@ declare module 'marked-highlight' {
    * A synchronous function to highlight code
    *
    * @param code The raw code to be highlighted
-   * @param language The language tag found immediately after the code block opening marker (e.g. ```typescript -> language='typescript')
+   * @param language The language tag found immediately after the code block
+   *   opening marker (e.g. ```typescript -> language='typescript')
    * @return The highlighted code as a HTML string
    */
   type SyncHighlightFunction = (code: string, language: string) => string;
@@ -12,34 +13,49 @@ declare module 'marked-highlight' {
    * An asynchronous function to highlight code
    *
    * @param code The raw code to be highlighted
-   * @param language The language tag found immediately after the code block opening marker (e.g. ```typescript -> language='typescript')
+   * @param language The language tag found immediately after the code block
+   *   opening marker (e.g. ```typescript -> language='typescript')
    * @return A Promise for the highlighted code as a HTML string
    */
   type AsyncHighlightFunction = (code: string, language: string) => Promise<string>;
 
   /**
-   * Options for configuring the marked-highlight extension using a synchronous highlighting function.
+   * Options for configuring the marked-highlight extension using a synchronous
+   * highlighting function.
    */
   interface SynchronousOptions {
     /** Function to highlight code with */
     highlight: SyncHighlightFunction;
-    /** Not necessary when using a synchronous highlighting function, but can be set without harm (will make `marked.parse()` return a promise if true) */
+    /**
+     * Not necessary when using a synchronous highlighting function, but can be
+     * set without harm (it will make `marked.parse()` return a promise if true;
+     * pass the {async: true} option to marked.parse() to tell TypeScript this)
+     */
     async?: boolean;
-    /** The language tag found immediately after the code block opening marker is appended to this to form the class attribute added to the <code> element. */
+    /**
+     * The language tag found immediately after the code block opening marker is
+     * appended to this to form the class attribute added to the <code> element.
+     */
     langPrefix?: string;
   }
 
   /**
-   * Options for configuring the marked-highlight extension using an asynchronous highlighting function.
+   * Options for configuring the marked-highlight extension using an
+   * asynchronous highlighting function.
    * 
-   * Note that the {async: true} option must also be passed to markdown.parse() when using an asynchronous highlighting function.
+   * Note that the {async: true} option should also be passed to marked.parse()
+   * when using an asynchronous highlighting function to tell TypeScript that it
+   * will return a Promise.
    */
   interface AsynchronousOptions {
     /** Function to highlight code with */
     highlight: AsyncHighlightFunction;
     /** Must be set to true when using an asynchronous highlight function */
     async: true;
-    /** The language tag found immediately after the code block opening marker is appended to this to form the class attribute added to the <code> element. */
+    /**
+     * The language tag found immediately after the code block opening marker is
+     * appended to this to form the class attribute added to the <code> element.
+     */
     langPrefix?: string;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ const escapeReplacements = {
   "'": '&#39;'
 };
 const getEscapeReplacement = (ch) => escapeReplacements[ch];
-export function escape(html, encode) {
+function escape(html, encode) {
   if (encode) {
     if (escapeTest.test(html)) {
       return html.replace(escapeReplace, getEscapeReplacement);


### PR DESCRIPTION
Fixes #23 

`npm run test` is failing on my machine, which I think is because I have bleeding edge python (specifically, because of https://github.com/python/cpython/issues/91222). They fail in the same manner at main/HEAD, so I don't think that's caused by my change. If you have Python 3.10 or lower installed, I'd appreciate you running the tests on my behalf.

I haven't added tests to assert that these typings are correct. Happy to try to add them if desired, using something like https://github.com/SamVerschueren/tsd?

I'm also not sure if the `encode` function is actually meant to be exported?