### PR TITLE
feat: use plaintext for code with none language defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export function markedHighlight(options) {
         const lang = (infoString || '').match(/\S*/)[0];
         const classAttr = lang
           ? ` class="${options.langPrefix}${escape(lang)}"`
-          : '';
+          : ` class="${options.langPrefix}plaintext"`;
         code = code.replace(/\n$/, '');
         return `<pre><code${classAttr}>${escaped ? code : escape(code, true)}\n</code></pre>`;
       }


### PR DESCRIPTION
\`\`\`
\`\`\`
Won't be added classes, so the CSS theme (for example hljs) would not work for this code block.
I suggest to add a default language type `plaintext`.