### PR TITLE
support mermaid diagrams

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ export function markedHighlight(options) {
           ? ` class="${options.langPrefix}${escape(lang)}"`
           : '';
         code = code.replace(/\n$/, '');
+        if (lang === "mermaid") return `<pre class="mermaid">${escaped ? code : escape(code, true)}</pre>`;
         return `<pre><code${classAttr}>${escaped ? code : escape(code, true)}\n</code></pre>`;
       }
     }


### PR DESCRIPTION
```js
if (lang === "mermaid") return `<pre class="mermaid">${escaped ? code : escape(code, true)}</pre>`;
```
I Added this line to prevent the renderer from injecting `code` tag and class attributes when using [mermaid](https://mermaid.js.org/intro/n00b-gettingStarted.html) code block. 
This way the user can use the [mermaid.js](https://mermaid.js.org/) to draw diagram in the webpage.
