### PR TITLE
fix: the exports not define types

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./src/index.d.ts",
       "import": "./src/index.js",
       "require": "./lib/index.cjs"
     }


### PR DESCRIPTION
If the user use the ts and set `moduleResolution: nodenext` of `tsconfig.json`, this type will not be available.

https://github.com/NWYLZW/How-to-publish-a-npm-package/blob/c1be086a620e0d594c014bcfa910cc1e3a79a56e/tests/marked-highlight/index.ts#L1

<img width="1160" alt="image" src="https://github.com/markedjs/marked-highlight/assets/51358815/c587fd82-7999-4288-9f92-01728b8990f6">

So we should set the `types` field for `package.json:exports:[.]`.

__The new support works similarly with [import conditions](https://nodejs.org/api/packages.html). By default, TypeScript overlays the same rules with import conditions - if you write an import from an ES module, it will look up the import field, and from a CommonJS module, it will look at the require field. If it finds them, it will look for a corresponding declaration file. If you need to point to a different location for your type declarations, you can add a "types" import condition.__[1]

[1] [TypeScript 4.7 ChangeLog](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#:~:text=The%20new%20support,types%22%20import%20condition.)